### PR TITLE
Closing DataOutputStream before calling toByteArray on the underlying ByteArrayOutputStream 

### DIFF
--- a/src/main/java/comparators/Composite.java
+++ b/src/main/java/comparators/Composite.java
@@ -279,6 +279,7 @@ public class Composite implements Collection<Object>, Comparable<Composite>
             try
             {
                 out.write(COMPONENT_STOP);
+                out.close();
             } catch (IOException e)
             {
                 logger.throwing("Composite", "pack", e);


### PR DESCRIPTION
When a `DataOutputStream` instance wraps an underlying `ByteArrayOutputStream` instance,
it is recommended to flush or close the `DataOutputStream` before invoking the underlying instances's toByteArray(). Also, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a close method before calling toByteArray().
